### PR TITLE
Add support for Terraform 0.12 (and a few other small fixes)

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -173,9 +173,10 @@ resource "kubernetes_service" "this" {
       target_port = "tiller"
     }
 
-    selector {
-      app  = "helm"
-      name = "tiller"
+    selector = {
+      "app.kubernetes.io/name"      = "helm"
+      "app.kubernetes.io/component" = "tiller"
+      "app.kubernetes.io/version"   = "${var.tiller_version}"
     }
 
     type = "${var.tiller_service_type}"

--- a/main.tf
+++ b/main.tf
@@ -77,6 +77,10 @@ resource "kubernetes_deployment" "this" {
         labels = {
           "app.kubernetes.io/name"      = "helm"
           "app.kubernetes.io/component" = "tiller"
+
+          # helm uses these pod labels to find tiller, so they must be set:
+          app  = "helm"
+          name = "tiller"
         }
       }
 

--- a/main.tf
+++ b/main.tf
@@ -7,13 +7,13 @@ resource "kubernetes_service_account" "this" {
     name      = "${var.tiller_service_account_name}"
     namespace = "${var.tiller_namespace}"
 
-    labels {
+    labels = {
       "app.kubernetes.io/name"       = "helm"
       "app.kubernetes.io/component"  = "tiller"
       "app.kubernetes.io/managed-by" = "terraform"
     }
 
-    annotations {
+    annotations = {
       "field.cattle.io/description" = "Helm Package Manager: required server-side component"
     }
   }
@@ -23,7 +23,7 @@ resource "kubernetes_cluster_role_binding" "this" {
   metadata {
     name = "tiller"
 
-    labels {
+    labels = {
       "app.kubernetes.io/name"       = "helm"
       "app.kubernetes.io/component"  = "tiller"
       "app.kubernetes.io/managed-by" = "terraform"
@@ -49,24 +49,24 @@ resource "kubernetes_deployment" "this" {
     name      = "tiller-deploy"
     namespace = "${var.tiller_namespace}"
 
-    labels {
+    labels = {
       "app.kubernetes.io/name"       = "helm"
       "app.kubernetes.io/component"  = "tiller"
       "app.kubernetes.io/managed-by" = "terraform"
       "app.kubernetes.io/version"    = "${var.tiller_version}"
     }
 
-    annotations {
+    annotations = {
       "field.cattle.io/description" = "Helm Package Manager: required server-side component"
     }
   }
 
   spec {
     replicas = 1
-    strategy = {}
+    strategy {}
 
     selector {
-      match_labels {
+      match_labels = {
         "app.kubernetes.io/name"      = "helm"
         "app.kubernetes.io/component" = "tiller"
       }
@@ -74,14 +74,13 @@ resource "kubernetes_deployment" "this" {
 
     template {
       metadata {
-        labels {
+        labels = {
           "app.kubernetes.io/name"      = "helm"
           "app.kubernetes.io/component" = "tiller"
         }
       }
 
       spec {
-
         volume {
           name = "${kubernetes_service_account.this.default_secret_name}"
           secret {
@@ -140,8 +139,8 @@ resource "kubernetes_deployment" "this" {
 
           volume_mount {
             mount_path = "/var/run/secrets/kubernetes.io/serviceaccount"
-            name = "${kubernetes_service_account.this.default_secret_name}"
-            read_only = true
+            name       = "${kubernetes_service_account.this.default_secret_name}"
+            read_only  = true
           }
 
           resources {}
@@ -153,13 +152,13 @@ resource "kubernetes_deployment" "this" {
 
 resource "kubernetes_service" "this" {
   metadata {
-    labels {
+    labels = {
       "app.kubernetes.io/name"       = "helm"
       "app.kubernetes.io/component"  = "tiller"
       "app.kubernetes.io/managed-by" = "terraform"
     }
 
-    annotations {
+    annotations = {
       "field.cattle.io/description" = "Helm Package Manager: required server-side component"
     }
 


### PR DESCRIPTION
Hi,

These changes add support for Terraform 0.12 (which is more strict about maps vs. blocks) and fix a few other small bugs we found while experimenting with this module. In particular:

* The service selector was not matching any pods because the labels didn't match.
* The Helm client couldn't find the pods because they didn't provide the [hard-coded labels used in the client](https://github.com/helm/helm/blob/e48a3be64af498c2a8891ca9244741f5ea1d26cc/pkg/helm/portforwarder/portforwarder.go#L34).

Let me know if you have any questions or would like me to make any changes! And thanks for the nice module!