### PR TITLE
Tiller has a new default location at ghcr.io/helm/tiller

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -196,7 +196,7 @@ resource "kubernetes_deployment" "this" {
             }
           }
 
-          image             = "gcr.io/kubernetes-helm/tiller:v${var.tiller_version}"
+          image             = "ghcr.io/helm/tiller:v${var.tiller_version}"
           image_pull_policy = var.tiller_image_pull_policy
 
           liveness_probe {

--- a/variables.tf
+++ b/variables.tf
@@ -1,6 +1,6 @@
 variable "tiller_version" {
   type        = string
-  default     = "2.14.3"
+  default     = "2.17.0"
   description = "Version of Tiller to be deployed."
 }
 


### PR DESCRIPTION
- Default location of Tiller is now `ghcr.io/helm/tiller` (the old location might be removed anytime after Helm v2 EOL). Note: Make sure to update Docker image location for existing Tiller components.
- Switch to latest stable Helm v2 release `2.17.0` with focus on supporting Helm v2 deprecation

> Helm v2.17.0 is a feature release of Helm v2. The focus of this release is the End of Life for Helm v2 support and the deprecation of the stable and incubator Helm chart repositories. The chart repositories are moving to a new location that will serve as a long term archive.

See Helm v2 :https://github.com/helm/helm/releases/tag/v2.17.0